### PR TITLE
ci: actions split to release and npm publish

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,29 @@
+name: Publish NPM Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 'lts/*'
+        registry-url: 'https://registry.npmjs.org/'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build the package
+      run: npm run build
+
+    - name: Publish to npm
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,4 @@ jobs:
         with:
           release-type: node
           package-name: interpol.ts
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to npm
-        if: ${{ steps.release.outcome == 'success' && steps.release.outputs.release_created == 'true' }}
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.AUTOMATE_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for automating the publishing of NPM packages upon release.

- **Bug Fixes**
	- Updated authentication token in the release workflow to enhance security.
	- Removed automatic publishing to NPM after a release to streamline the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->